### PR TITLE
Rename styled-yaml to styled_yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Psych extension to enable choosing output styles for specific objects.
 ## Usage
 
 ```ruby
-require 'styled-yaml'
+require 'styled_yaml'
 require 'yaml'
 
 recipe = {

--- a/styled_yaml.gemspec
+++ b/styled_yaml.gemspec
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |spec|
-  spec.name        = 'styled-yaml'
+  spec.name        = 'styled_yaml'
   spec.summary     = 'A Psych extension to enable choosing output styles for specific objects.'
   spec.version     = '0.0.1'
   spec.authors     = ['James Ramsay']


### PR DESCRIPTION
In accordance with Gem naming guidelines, correct the name of the Gem.